### PR TITLE
Return full path to avoid IsADirectoryError

### DIFF
--- a/csp_billing_adapter_local/plugin.py
+++ b/csp_billing_adapter_local/plugin.py
@@ -40,8 +40,7 @@ def get_local_path(filename):
     local_storage_path = Path(ADAPTER_DATA_DIR)
     if not local_storage_path.exists():
         local_storage_path.mkdir(parents=True, exist_ok=True)
-    local_storage_path.joinpath(filename)
-    return local_storage_path
+    return local_storage_path.joinpath(filename)
 
 
 @csp_billing_adapter.hookimpl(trylast=True)

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -50,8 +50,12 @@ local_config = Config.load_from_file(
 
 def test_local_get_local_path():
     """Test get_local_path(filename) in local plugin"""
-    expected_path = Path('/var/lib/csp-billing-adapter/foo')
-    assert get_local_path('foo') == expected_path
+    with patch(
+        'csp_billing_adapter_local.plugin.Path',
+        return_value=Path('/etc/')
+    ):
+        expected_path = Path('/etc/foo')
+        assert get_local_path('foo') == expected_path
 
 
 def test_local_get_cache():

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -31,6 +31,7 @@ from csp_billing_adapter.adapter import get_plugin_manager
 
 
 from csp_billing_adapter_local.plugin import (
+    get_local_path,
     get_cache,
     get_csp_config,
     update_cache,
@@ -45,6 +46,12 @@ local_config = Config.load_from_file(
         config_file,
         pm.hook
     )
+
+
+def test_local_get_local_path():
+    """Test get_local_path(filename) in local plugin"""
+    expected_path = Path('/var/lib/csp-billing-adapter/foo')
+    assert get_local_path('foo') == expected_path
 
 
 def test_local_get_cache():


### PR DESCRIPTION
When getting local path, the full path is not returned only the directory (ADAPTER_DATA_DIR) raising an IsADirectoryError when opening the CSP config file

Return the full path, directory + filename

Add test for get_local_path(filename) method