### PR TITLE
Add typing hint for get_local_path method

### DIFF
--- a/csp_billing_adapter_local/plugin.py
+++ b/csp_billing_adapter_local/plugin.py
@@ -35,7 +35,7 @@ CACHE_FILE = 'cache.json'
 CSP_CONFIG_FILE = 'csp-config.json'
 
 
-def get_local_path(filename):
+def get_local_path(filename: str):
     """Return the requested data file path"""
     local_storage_path = Path(ADAPTER_DATA_DIR)
     if not local_storage_path.exists():


### PR DESCRIPTION
Currently, the helper methods do not have type hints, only main methods
While I understand that I think it is benefitial to have type hints in helper methods as well 