### PR TITLE
Switch build

### DIFF
--- a/csp-billing-adapter-local.spec
+++ b/csp-billing-adapter-local.spec
@@ -15,9 +15,9 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
-%global skip_python2 1
-%define pythons python3
+
+%{?sle15_python_module_pythons}
+
 Name:           csp-billing-adapter-local
 Version:        0.5.1
 Release:        0
@@ -28,9 +28,11 @@ URL:            https://github.com/SUSE-Enceladus/%{name}
 Source:         https://files.pythonhosted.org/packages/source/c/%{name}/%{name}-%{version}.tar.gz
 BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module pip}
 BuildRequires:  %{python_module pluggy}
 BuildRequires:  %{python_module csp-billing-adapter >= 0.5.1}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module wheel}
 %if %{with test}
 BuildRequires:  %{python_module pytest}
 BuildRequires:  %{python_module coverage}
@@ -50,10 +52,10 @@ storage of data using local resources.
 %autosetup -n %{name}-%{version}
 
 %build
-%python_build
+%pyproject_wheel
 
 %install
-%python_install
+%pyproject_install
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
 %check


### PR DESCRIPTION
Use wheel based build and build for different Python interpreters, Python 3.11 in SLE 15 Sp4 and later.